### PR TITLE
chore!: require Node ^20.19.0 || ^22.13.0 || >=24

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -17,5 +17,5 @@ jobs:
   test:
     uses: voxpelli/ghatemplates/.github/workflows/test.yml@main
     with:
-      node-versions: '18,20,21'
+      node-versions: '20,22,24,25'
       os: 'ubuntu-latest,windows-latest'

--- a/.github/workflows/ts-internal.yml
+++ b/.github/workflows/ts-internal.yml
@@ -19,5 +19,5 @@ jobs:
   type-check:
     uses: voxpelli/ghatemplates/.github/workflows/type-check.yml@main
     with:
-      ts-versions: ${{ github.event.schedule && 'next' || '5.6,next' }}
+      ts-versions: ${{ github.event.schedule && 'next' || '5.8,5.9,next' }}
       ts-libs: 'es2022;esnext'

--- a/.github/workflows/ts.yml
+++ b/.github/workflows/ts.yml
@@ -20,6 +20,6 @@ jobs:
     uses: voxpelli/ghatemplates/.github/workflows/type-check.yml@main
     with:
       ts-prebuild-script: 'build'
-      ts-versions: ${{ github.event.schedule && 'next' || '5.0,5.1,5.2,5.3,5.4,5.5,5.6,next' }}
+      ts-versions: ${{ github.event.schedule && 'next' || '5.8,5.9,next' }}
       ts-libs: 'es2022;esnext'
       ts-working-directory: 'test-published-types'

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   "dependencies": {
     "buffered-async-iterable": "^1.0.1",
     "pony-cause": "^2.1.10",
-    "read-pkg": "^9.0.1",
+    "read-pkg": "^10.1.0",
     "read-workspaces": "^1.2.0"
   },
   "devDependencies": {
@@ -53,10 +53,10 @@
     "@types/chai-as-promised": "^7.1.8",
     "@types/mocha": "^10.0.10",
     "@types/node": "^20.19.33",
-    "@types/sinon": "^17.0.4",
+    "@types/sinon": "^21.0.0",
     "@types/sinon-chai": "^3.2.12",
     "@voxpelli/eslint-config": "^23.0.0",
-    "@voxpelli/tsconfig": "^15.1.2",
+    "@voxpelli/tsconfig": "^16.1.0",
     "c8": "^10.1.3",
     "chai": "^4.5.0",
     "chai-as-promised": "^7.1.2",
@@ -64,14 +64,14 @@
     "desm": "^1.3.1",
     "eslint": "^9.39.3",
     "husky": "^9.1.7",
-    "installed-check": "^9.3.0",
+    "installed-check": "^10.0.0",
     "knip": "^5.85.0",
-    "mocha": "^10.8.2",
-    "npm-run-all2": "^6.2.6",
-    "sinon": "^19.0.5",
+    "mocha": "^11.7.5",
+    "npm-run-all2": "^8.0.4",
+    "sinon": "^21.0.1",
     "sinon-chai": "^3.7.0",
     "type-coverage": "^2.29.7",
-    "typescript": "~5.8.3",
+    "typescript": "~5.9.0",
     "validate-conventional-commit": "^1.0.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "husky": "^9.1.7",
     "installed-check": "^10.0.0",
     "knip": "^5.85.0",
-    "mocha": "^11.7.5",
+    "mocha": "^10.8.2",
     "npm-run-all2": "^8.0.4",
     "sinon": "^21.0.1",
     "sinon-chai": "^3.7.0",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "author": "Pelle Wessman <pelle@kodfabrik.se> (http://kodfabrik.se/)",
   "license": "0BSD",
   "engines": {
-    "node": ">=18.6.0"
+    "node": "^20.19.0 || ^22.13.0 || >=24"
   },
   "dependencies": {
     "buffered-async-iterable": "^1.0.1",
@@ -52,7 +52,7 @@
     "@types/chai": "^4.3.20",
     "@types/chai-as-promised": "^7.1.8",
     "@types/mocha": "^10.0.10",
-    "@types/node": "^18.19.86",
+    "@types/node": "^20.19.33",
     "@types/sinon": "^17.0.4",
     "@types/sinon-chai": "^3.2.12",
     "@voxpelli/eslint-config": "^23.0.0",

--- a/test-published-types/tsconfig.json
+++ b/test-published-types/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@voxpelli/tsconfig/legacy.json",
+  "extends": "@voxpelli/tsconfig/node20.json",
 
   "files": [
     "index.js"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@voxpelli/tsconfig/node18.json",
+  "extends": "@voxpelli/tsconfig/node20.json",
   "files": [
     "index.js",
   ],


### PR DESCRIPTION
Require Node.js versions ^20.19.0, ^22.13.0, or >=24 and update various development dependencies to their latest versions. Adjust the configuration to extend from the appropriate TypeScript configuration for Node.js 20.